### PR TITLE
Fix area/label redirect

### DIFF
--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -29,7 +29,9 @@ final _matchers = <RegExp, Uri Function(String)>{
   RegExp(r'^/opened/([A-Za-z0-9\-]+)$'): _openedIssues.resolve,
   RegExp(r'^/area/([A-Za-z0-9\-]+)$'): (match) => _listIssues.replace(
         queryParameters: {
-          'label': 'area-$match',
+          'q': [
+            'label:area-$match',
+          ].join(' '),
         },
       ),
   RegExp(r'^/triage$', caseSensitive: false): (_) => _listIssues.replace(


### PR DESCRIPTION
Previously https://dartbug.com/area/analyzer led to https://github.com/dart-lang/sdk/issues?label=area-analyzer which doesn't result in filtering by `area-analyzer`.

This change properly redirects the user to https://github.com/dart-lang/sdk/issues?q=label%3Aarea-analyzer which includes only issues with the `area-analyzer` label. 