### PR TITLE
Improve .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
+.dockerignore
+Dockerfile
 .dart_tool/
-pubspec.lock
+.git/
+.github/
+.gitignore
+.idea/
+.packages


### PR DESCRIPTION
We shouldn't exclude pubspec.lock, because if we do we might deploy something different than what we test.