### PR TITLE
use a 302 / temporary redirect

### DIFF
--- a/lib/server.dart
+++ b/lib/server.dart
@@ -62,7 +62,8 @@ Allow: /
   final location = findRedirect(request.requestedUri);
   if (location != null) {
     _redirects++;
-    return Response.movedPermanently(location);
+    // Issue a 302 / Found ('Moved temporarily') redirect.
+    return Response.found(location);
   } else {
     _notFound++;
     return Response.notFound(


### PR DESCRIPTION
- use a 302 / temporary redirect

I'm not seeing new updates to the `dartbug.com/triage/core/issues` link - I think my browser is remembering the previous redirect as we were returning a 301 / permanent redirect.

We could also play with the cache control header as well.