### PR TITLE
update the inbox query for PRs

### DIFF
--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -77,9 +77,9 @@ final _matchers = <RegExp, Uri Function(String)>{
         'q': [
           'is:pr',
           'is:open',
-          'created:>$dateOneMonth',
           'review:none',
           '-draft:true',
+          'created:>$dateOneMonth',
           ...corePackages.map((repo) => 'repo:$repo'),
         ].join(' '),
       },
@@ -111,9 +111,9 @@ final _matchers = <RegExp, Uri Function(String)>{
         'q': [
           'is:pr',
           'is:open',
-          'created:>$dateOneMonth',
           'review:none',
           '-draft:true',
+          'created:>$dateOneMonth',
           ...toolsPackages.map((repo) => 'repo:$repo'),
         ].join(' '),
       },

--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -55,6 +55,7 @@ final _matchers = <RegExp, Uri Function(String)>{
   // core packages triage
   RegExp(r'^/triage/core$'): (_) => Uri.parse('$dartBug/triage/core/issues'),
   RegExp(r'^/triage/core/issues$'): (_) {
+    // Issues opened in the last 30 days not marked as bugs or enhancements.
     return Uri.parse('$gitHub/issues').replace(
       queryParameters: {
         'q': [
@@ -69,16 +70,16 @@ final _matchers = <RegExp, Uri Function(String)>{
     );
   },
   RegExp(r'^/triage/core/prs$'): (_) {
-    // TODO: This returns all open PRs; we need to determine what an inbox query
-    // looks like for PRs (new PRs? New and 'needs-attention'?).
+    // PRs opened in the last 30 days that haven't been assigned a reviewer and
+    // that aren't draft PRs.
     return Uri.parse('$gitHub/issues').replace(
       queryParameters: {
         'q': [
           'is:pr',
           'is:open',
-          // 'created:>$dateOneMonth',
-          // '-label:bug',
-          // '-label:enhancement',
+          'created:>$dateOneMonth',
+          'review:none',
+          '-draft:true',
           ...corePackages.map((repo) => 'repo:$repo'),
         ].join(' '),
       },
@@ -88,6 +89,7 @@ final _matchers = <RegExp, Uri Function(String)>{
   // tools packages triage
   RegExp(r'^/triage/tools$'): (_) => Uri.parse('$dartBug/triage/tools/issues'),
   RegExp(r'^/triage/tools/issues$'): (_) {
+    // Issues opened in the last 30 days not marked as bugs or enhancements.
     return Uri.parse('$gitHub/issues').replace(
       queryParameters: {
         'q': [
@@ -102,16 +104,16 @@ final _matchers = <RegExp, Uri Function(String)>{
     );
   },
   RegExp(r'^/triage/tools/prs$'): (_) {
-    // TODO: This returns all open PRs; we need to determine what an inbox query
-    // looks like for PRs (new PRs? New and 'needs-attention'?).
+    // PRs opened in the last 30 days that haven't been assigned a reviewer and
+    // that aren't draft PRs.
     return Uri.parse('$gitHub/issues').replace(
       queryParameters: {
         'q': [
           'is:pr',
           'is:open',
-          // 'created:>$dateOneMonth',
-          // '-label:bug',
-          // '-label:enhancement',
+          'created:>$dateOneMonth',
+          'review:none',
+          '-draft:true',
           ...toolsPackages.map((repo) => 'repo:$repo'),
         ].join(' '),
       },

--- a/test/redirect_test.dart
+++ b/test/redirect_test.dart
@@ -109,7 +109,7 @@ void main() {
             .toString(),
         startsWith(
           'https://github.com/issues?q=is%3Apr+is%3Aopen'
-          '+repo%3Adart-lang%2Fargs+',
+          '+review%3Anone+-draft%3Atrue+created',
         ),
       );
     });


### PR DESCRIPTION
- update the inbox query for PRs

This tightens our criteria for the PR inbox query to:
- newer issues (last 30 days)
- ones that haven't yet been assigned a reviewer
- ones that aren't in a 'draft' state
