### PR TITLE
Add forwarding to the language repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Simple redirector to the Dart issue tracker.
     dartbug.com/triage/tools         --> an alias for 'triage/tools/issues'
     dartbug.com/triage/tools/issues  --> untriaged issues for the Dart tools packages (tools.dart.dev published)
     dartbug.com/triage/tools/prs     --> untriaged PRs for the Dart tools packages (tools.dart.dev published)
+    dartbug.com/language             --> issues list for language repo
+    dartbug.com/language/new         --> new issue template in language repo
+    dartbug.com/language/<nunmber>   --> specific issue in language repo
+    dartbug.com/language/opened/<user-id>   --> issues opened by github user <user-id> in language repo
+    dartbug.com/language/assigned/<user-id> --> issues assigned to github user <user-id> in language repo
+    dartbug.com/l                    --> shorthand for /language
 
 See the [LICENSE](LICENSE) file.
 
@@ -48,4 +54,3 @@ Following instructions at https://cloud.google.com/run/docs/quickstarts/build-an
 $ dart tool/update_sdk_labels.dart
 ```
 
-❓

--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -147,8 +147,9 @@ final _matchers = <RegExp, Uri Function(Match)>{
 /// and [base2] otherwise.
 /// (The former is an SDK repo base, the latter a language repo base.)
 Uri Function(Match) _resolveLastChoose(Uri base1, Uri base2) => (Match match) {
-      return ((match[1] == null) ? base1 : base2)
-          .resolve(match[match.groupCount]!);
+      return ((match[1] == null) ? base1 : base2).resolve(
+        match[match.groupCount]!,
+      );
     };
 
 final List<String> _areaLabels = List<String>.from(

--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -32,15 +32,18 @@ final _languageOpenedIssues = Uri.parse('$_languageRootUri/issues/created_by/');
 Iterable<String> get routes => _matchers.keys.map((r) => r.pattern);
 
 final _matchers = <RegExp, Uri Function(Match)>{
+  // Operations that also work on language repo.
   RegExp(r'^/(l(?:anguage)?)$'): (_) => _languageListIssues,
   RegExp(r'^/(l(?:anguage)?/)?([0-9]+)$'):
       _resolveLastChoose(_showIssue, _languageShowIssue),
-  RegExp(r'^/(l(?:anguage)?/)?new$', caseSensitive: false):
-      _resolveLastChoose(_newIssue, _languageNewIssue),
+  RegExp(r'^/(l(?:anguage)?/)?new$', caseSensitive: false): (match) =>
+      match[1] == null ? _newIssue : _languageNewIssue,
   RegExp(r'^/(l(?:anguage)?/)?assigned/([A-Za-z0-9\-]+)$'):
       _resolveLastChoose(_assignedIssues, _languageAssignedIssues),
   RegExp(r'^/(l(?:anguage)?/)?opened/([A-Za-z0-9\-]+)$'):
       _resolveLastChoose(_openedIssues, _languageOpenedIssues),
+
+  // SDK repo only.
   RegExp(r'^/area/([A-Za-z0-9\-]+)$'): (match) {
     return _listIssues.replace(
       queryParameters: {

--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -147,9 +147,8 @@ final _matchers = <RegExp, Uri Function(Match)>{
 /// and [base2] otherwise.
 /// (The former is an SDK repo base, the latter a language repo base.)
 Uri Function(Match) _resolveLastChoose(Uri base1, Uri base2) => (Match match) {
-      return ((match[1] == null) ? base1 : base2).resolve(
-        match[match.groupCount]!,
-      );
+      return ((match[1] == null) ? base1 : base2)
+          .resolve(match[match.groupCount]!);
     };
 
 final List<String> _areaLabels = List<String>.from(

--- a/lib/redirect.dart
+++ b/lib/redirect.dart
@@ -11,6 +11,7 @@ import 'dart:io';
 const gitHub = 'https://github.com';
 const organization = 'dart-lang';
 const repository = 'sdk';
+const languageRepository = 'language';
 const dartBug = 'https://dartbug.com';
 
 // Redirect URIs
@@ -21,18 +22,30 @@ final _newIssue = Uri.parse('$_rootUri/issues/new');
 final _assignedIssues = Uri.parse('$_rootUri/issues/assigned/');
 final _openedIssues = Uri.parse('$_rootUri/issues/created_by/');
 
+const _languageRootUri = '$gitHub/$organization/$languageRepository';
+final _languageListIssues = Uri.parse('$_languageRootUri/issues');
+final _languageShowIssue = Uri.parse('$_languageRootUri/issues/');
+final _languageNewIssue = Uri.parse('$_languageRootUri/issues/new');
+final _languageAssignedIssues = Uri.parse('$_languageRootUri/issues/assigned/');
+final _languageOpenedIssues = Uri.parse('$_languageRootUri/issues/created_by/');
+
 Iterable<String> get routes => _matchers.keys.map((r) => r.pattern);
 
-final _matchers = <RegExp, Uri Function(String)>{
-  RegExp(r'^/([0-9]+)$'): _showIssue.resolve,
-  RegExp(r'^/new$', caseSensitive: false): (_) => _newIssue,
-  RegExp(r'^/assigned/([A-Za-z0-9\-]+)$'): _assignedIssues.resolve,
-  RegExp(r'^/opened/([A-Za-z0-9\-]+)$'): _openedIssues.resolve,
+final _matchers = <RegExp, Uri Function(Match)>{
+  RegExp(r'^/(l(?:anguage)?)$'): (_) => _languageListIssues,
+  RegExp(r'^/(l(?:anguage)?/)?([0-9]+)$'):
+      _resolveLastChoose(_showIssue, _languageShowIssue),
+  RegExp(r'^/(l(?:anguage)?/)?new$', caseSensitive: false):
+      _resolveLastChoose(_newIssue, _languageNewIssue),
+  RegExp(r'^/(l(?:anguage)?/)?assigned/([A-Za-z0-9\-]+)$'):
+      _resolveLastChoose(_assignedIssues, _languageAssignedIssues),
+  RegExp(r'^/(l(?:anguage)?/)?opened/([A-Za-z0-9\-]+)$'):
+      _resolveLastChoose(_openedIssues, _languageOpenedIssues),
   RegExp(r'^/area/([A-Za-z0-9\-]+)$'): (match) {
     return _listIssues.replace(
       queryParameters: {
         'q': [
-          'label:area-$match',
+          'label:area-${match[1]}',
         ].join(' '),
       },
     );
@@ -125,14 +138,15 @@ final _matchers = <RegExp, Uri Function(String)>{
   },
 };
 
-String? _checkMatch(RegExp re, String path) {
-  final match = re.firstMatch(path);
-  if (match != null) {
-    return match.group(match.groupCount)!;
-  } else {
-    return null;
-  }
-}
+/// Resolves one of [base1] or [base2] against the last capture of `match`.
+///
+/// Chooses [base1] if the first capture (`match[1]`) is `null`,
+/// and [base2] otherwise.
+/// (The former is an SDK repo base, the latter a language repo base.)
+Uri Function(Match) _resolveLastChoose(Uri base1, Uri base2) => (Match match) {
+      return ((match[1] == null) ? base1 : base2)
+          .resolve(match[match.groupCount]!);
+    };
 
 final List<String> _areaLabels = List<String>.from(
   jsonDecode(
@@ -154,7 +168,7 @@ Uri? findRedirect(Uri requestUri) {
   }
 
   for (var entry in _matchers.entries) {
-    final match = _checkMatch(entry.key, requestUri.path);
+    final match = entry.key.firstMatch(requestUri.path);
     if (match != null) {
       return entry.value(match);
     }

--- a/test/redirect_test.dart
+++ b/test/redirect_test.dart
@@ -114,4 +114,62 @@ void main() {
       );
     });
   });
+
+  group('language repository', () {
+    const repository = 'language';
+
+    for (var prefix in ['l', 'language']) {
+      group('(/$prefix)', () {
+        test('issue number', () {
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix/1234'))
+                .toString(),
+            '$gitHub/$organization/$repository/issues/1234',
+          );
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix/-1234')),
+            isNull,
+          );
+        });
+
+        test('new issue', () {
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix/new'))
+                .toString(),
+            '$gitHub/$organization/$repository/issues/new',
+          );
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix/NEW'))
+                .toString(),
+            '$gitHub/$organization/$repository/issues/new',
+          );
+        });
+
+        test('assigned issue', () {
+          expect(
+            findRedirect(
+                    Uri.parse('http://dartbug.com/$prefix/assigned/kevmoo'))
+                .toString(),
+            '$gitHub/$organization/$repository/issues/assigned/kevmoo',
+          );
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix/assigned/nex3'))
+                .toString(),
+            '$gitHub/$organization/$repository/issues/assigned/nex3',
+          );
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix/søren')),
+            isNull,
+          );
+        });
+
+        test('list issues', () {
+          expect(
+            findRedirect(Uri.parse('http://dartbug.com/$prefix')).toString(),
+            '$gitHub/$organization/$repository/issues',
+          );
+        });
+      });
+    }
+  });
 }

--- a/test/redirect_test.dart
+++ b/test/redirect_test.dart
@@ -148,8 +148,8 @@ void main() {
         test('assigned issue', () {
           expect(
             findRedirect(
-                    Uri.parse('http://dartbug.com/$prefix/assigned/kevmoo'))
-                .toString(),
+              Uri.parse('http://dartbug.com/$prefix/assigned/kevmoo'),
+            ).toString(),
             '$gitHub/$organization/$repository/issues/assigned/kevmoo',
           );
           expect(


### PR DESCRIPTION
Starting with `language/` or just `l/` forwards the non-triage/non-label related operations to the language repository instead of the SDK repository.

